### PR TITLE
Setting window identiifiers for Workspace Extension

### DIFF
--- a/Lib/xTools4/dialogs/glyphs/old/layersImport.py
+++ b/Lib/xTools4/dialogs/glyphs/old/layersImport.py
@@ -34,6 +34,7 @@ class ImportGlyphsIntoLayerDialog(hDialog):
         self.height  = self.textHeight * 8
         self.height += self.padding * 9
         self.w = self.window((self.width, self.height), self.title)
+        self.w.workspaceWindowIdentifier = "LayerImport"
 
         x = y = p = self.padding
         self.w.getFile = Button(

--- a/Lib/xTools4/dialogs/glyphs/old/layersMask.py
+++ b/Lib/xTools4/dialogs/glyphs/old/layersMask.py
@@ -31,6 +31,7 @@ class MaskDialog(hDialog, BaseWindowController):
         self.height  = self.textHeight * 9
         self.height += self.padding * 6 -5
         self.w = self.window((self.width, self.height), self.title)
+        self.w.workspaceWindowIdentifier = "LayerMask"
 
         x = p = self.padding
         y = p - 3

--- a/Lib/xTools4/dialogs/variable/GlyphMeme.py
+++ b/Lib/xTools4/dialogs/variable/GlyphMeme.py
@@ -88,6 +88,7 @@ class GlyphMemeController(ezui.WindowController):
             minSize=(123, 300),
             maxSize=(123, 960),
         )
+        self.w.workspaceWindowIdentifier = "GlyphMeme"
         self.w.getNSWindow().setTitlebarAppearsTransparent_(True)
         self.w.getItem("glyphMeme").getNSTableView().setRowHeight_(17)
         self.w.open()

--- a/Lib/xTools4/dialogs/variable/GlyphValidator.py
+++ b/Lib/xTools4/dialogs/variable/GlyphValidator.py
@@ -106,6 +106,7 @@ class GlyphValidatorController(ezui.WindowController):
             margins=self.margins,
             size=(self.width, 'auto'),
         )
+        self.w.workspaceWindowIdentifier = "GlyphValidator"
         self.w.getNSWindow().setTitlebarAppearsTransparent_(True)
         self.w.open()
 

--- a/Lib/xTools4/dialogs/variable/Measurements.py
+++ b/Lib/xTools4/dialogs/variable/Measurements.py
@@ -458,6 +458,7 @@ class MeasurementsController(ezui.WindowController):
             size=(800, 600),
             minSize=(600, 400),
         )
+        self.w.workspaceWindowIdentifier = "Measurements"
         self.w.getNSWindow().setTitlebarAppearsTransparent_(True)
         self.w.getItem("fontMeasurements").getNSTableView().setRowHeight_(17)
         self.w.getItem("glyphMeasurements").getNSTableView().setRowHeight_(17)


### PR DESCRIPTION
I think it could be useful to have xTools speak with Workspaces Extension
Here is the documentation of window identification. 
https://github.com/typesupply/workspaces/blob/main/source/documentation/index.md#setting-a-window-identifier